### PR TITLE
updated config and setup to use zipcode-themed subforum names

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,8 +3,8 @@ from app import app
 
 SECRET_KEY = os.environ['SECRET_KEY']
 #SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
-SITE_NAME = "Default Forum Name"
-SITE_DESCRIPTION = "Change this value in config.py"
+SITE_NAME = "Zip Code Cafe"
+SITE_DESCRIPTION = "Where knowledge is power"
 username = os.getenv('MYSQL_user')
 pswd = os.getenv('MYSQL_pw')
 #SQLALCHEMY_DATABASE_URI = "sqlite:////tmp/database.db";

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,12 @@ from database import *
 
 import os
 def init_site():
-	admin = add_subforum("Forum", "Announcements")
+	admin = add_subforum("News", "Announcements")
 	add_subforum("Announcements", "View forum announcements here",admin)
-	add_subforum("Bug Reports", "Report bugs with the forum here", admin)
-	add_subforum("General Discussion", "Use this subforum to post anything you want")
-	add_subforum("Coding Discussion", "Discuss other things here")
+	add_subforum("Bugs", "Report bugs with the forum here", admin)
+	add_subforum("Learn to Code", "Share resources, tips, and tricks")
+	add_subforum("Lab Help", "Ask questions related to labs")
+	add_subforum("Alumni", "Zip Code alumni networking")
 
 def add_subforum(title, description, parent=None):
 	sub = Subforum(title, description)


### PR DESCRIPTION
I changed the auto-subforum columns to fit our new theme. I'll push my updates to the dev branch and make a pull request. If you've gotten the program running, your mysql will still have the old column names but if you drop the tables in your own mysql "post" database, you'll see the changes the next time you run the program.